### PR TITLE
Edit delete contribution

### DIFF
--- a/BrainfarmService/BrainfarmService.svc.cs
+++ b/BrainfarmService/BrainfarmService.svc.cs
@@ -198,7 +198,8 @@ namespace BrainfarmService
         {
             if (bodyText == null || bodyText == "")
             {
-                throw new FaultException("Comment Body must not be empty");
+                throw new FaultException("Comment Body must not be empty",
+                    new FaultCode("MISSING_COMMENT_BODY"));
             }
 
             // Get user from session
@@ -223,11 +224,12 @@ namespace BrainfarmService
 
         public Comment EditComment(string sessionToken, int commentID,
             string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
-            SynthesisRequest[] syntheses)
+            SynthesisRequest[] syntheses, FileAttachmentRequest[] attachments)
         {
             if (bodyText == null || bodyText == "")
             {
-                throw new FaultException("Comment Body must not be empty");
+                throw new FaultException("Comment Body must not be empty",
+                    new FaultCode("MISSING_COMMENT_BODY"));
             }
 
             // Get user from session
@@ -238,7 +240,8 @@ namespace BrainfarmService
                 using (CommentDBAccess commentDBAccess = new CommentDBAccess())
                 {
                     int rowsAffected = commentDBAccess.EditComment(commentID, user.UserID, 
-                        bodyText, isSynthesis, isContribution, isSpecification, syntheses);
+                        bodyText, isSynthesis, isContribution, isSpecification, 
+                        syntheses, attachments);
                     if (rowsAffected == 0)
                     {
                         throw new FaultException("Unable to edit comment",

--- a/BrainfarmService/BrainfarmService.svc.cs
+++ b/BrainfarmService/BrainfarmService.svc.cs
@@ -239,6 +239,11 @@ namespace BrainfarmService
             {
                 using (CommentDBAccess commentDBAccess = new CommentDBAccess())
                 {
+                    // Throw exception if user is not comment owner
+                    if (commentDBAccess.GetComment(commentID).UserID != user.UserID)
+                        throw new FaultException("You do not have permission to do that",
+                            new FaultCode("INVALID_PERMISSIONS"));
+
                     int rowsAffected = commentDBAccess.EditComment(commentID, user.UserID, 
                         bodyText, isSynthesis, isContribution, isSpecification, 
                         syntheses, attachments);
@@ -417,7 +422,12 @@ namespace BrainfarmService
             {
                 using (CommentDBAccess commentDBAccess = new CommentDBAccess())
                 {
-                    int rowsAffected = commentDBAccess.RemoveComment(commentID, user.UserID);
+                    // Throw exception if user is not comment owner
+                    if (commentDBAccess.GetComment(commentID).UserID != user.UserID)
+                        throw new FaultException("You do not have permission to do that",
+                            new FaultCode("INVALID_PERMISSIONS"));
+
+                    int rowsAffected = commentDBAccess.RemoveComment(commentID);
 
                     if (rowsAffected == 0)
                     {

--- a/BrainfarmService/Data/CommentDBAccess.cs
+++ b/BrainfarmService/Data/CommentDBAccess.cs
@@ -54,8 +54,6 @@ VALUES(@ProjectID
             string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
             SynthesisRequest[] syntheses, FileAttachmentRequest[] attachments)
         {
-            // TODO: Implement this method
-
             BeginTransaction();
 
             try
@@ -115,6 +113,7 @@ VALUES(@ProjectID
             string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
             SynthesisRequest[] syntheses, FileAttachmentRequest[] attachments)
         {
+            BeginTransaction();
             int rowsAffected;
 
             try
@@ -137,31 +136,29 @@ VALUES(@ProjectID
 
                 // Do not make changes to contribution files if the comment is still a 
                 //contribution comment and no attachments were specified.
-                using (ContributionFileDBAccess contributionFileDBAccess
-                    = new ContributionFileDBAccess(this))
+                ContributionFileDBAccess contributionFileDBAccess
+                    = new ContributionFileDBAccess(this);
+                if (isContribution)
                 {
-                    if (isContribution)
+                    if (attachments != null && attachments.Length > 0)
                     {
-                        if (attachments != null && attachments.Length > 0)
-                        {
-                            // Comment is a contribution and new files have been specified
+                        // Comment is a contribution and new files have been specified
 
-                            // Remove existing contribution files
-                            contributionFileDBAccess.DeleteAllFilesForComment(commentID);
-                            // Attach each contribution file
-                            foreach (FileAttachmentRequest attachment in attachments)
-                            {
-                                contributionFileDBAccess.AttachFileToComment(
-                                    attachment.ContributionFileID, commentID, attachment.Filename);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Comment is not a contribution
                         // Remove existing contribution files
                         contributionFileDBAccess.DeleteAllFilesForComment(commentID);
+                        // Attach each contribution file
+                        foreach (FileAttachmentRequest attachment in attachments)
+                        {
+                            contributionFileDBAccess.AttachFileToComment(
+                                attachment.ContributionFileID, commentID, attachment.Filename);
+                        }
                     }
+                }
+                else
+                {
+                    // Comment is not a contribution
+                    // Remove existing contribution files
+                    contributionFileDBAccess.DeleteAllFilesForComment(commentID);
                 }
 
                 Commit();

--- a/BrainfarmService/Data/ContributionFileDBAccess.cs
+++ b/BrainfarmService/Data/ContributionFileDBAccess.cs
@@ -137,5 +137,17 @@ SELECT ContributionFileID
             return contributionFiles;
         }
 
+        public int DeleteAllFilesForComment(int commentID) {
+            string sql = @"
+DELETE ContributionFile
+ WHERE CommentID = @CommentID
+";
+            using (SqlCommand command = GetNewCommand(sql))
+            {
+                command.Parameters.AddWithValue("@CommentID", commentID);
+                return command.ExecuteNonQuery();
+            }
+        }
+
     }
 }

--- a/BrainfarmService/IBrainfarmService.cs
+++ b/BrainfarmService/IBrainfarmService.cs
@@ -63,16 +63,6 @@ namespace BrainfarmService
         [OperationContract]
         [WebInvoke]
         Project CreateProject(string sessionToken, string title, string[] tags, string firstCommentBody);
-
-        [OperationContract]
-        [WebInvoke]
-        Comment EditComment(string sessionToken, int commentID,
-            string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
-            SynthesisRequest[] syntheses);
-
-        [OperationContract]
-        [WebInvoke]
-        int RemoveComment(string sessionToken, int commentID);
         
         [OperationContract]
         [WebInvoke]
@@ -81,15 +71,40 @@ namespace BrainfarmService
         [OperationContract]
         [WebInvoke]
         Comment CreateComment(string sessionToken, int projectID, int parentCommentID, 
-            string bodyText, bool isSynthesis, bool isContribution, bool isSpecification, 
+            string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
             SynthesisRequest[] syntheses, FileAttachmentRequest[] attachments);
+
+        /// <summary>
+        /// Edit an existing comment.
+        /// </summary>
+        /// <param name="sessionToken">Token identifying current user. Obtained from Login method.</param>
+        /// <param name="commentID">ID of comment to edit</param>
+        /// <param name="bodyText">New body text of comment</param>
+        /// <param name="isSynthesis">Bool specifying if comment is a synthesis</param>
+        /// <param name="isContribution">Bool specifying if comment is a contribution</param>
+        /// <param name="isSpecification">Bool specifying if comment is a specification</param>
+        /// <param name="syntheses">Array of SynthesisRequest objects specifying links to other comments</param>
+        /// <param name="attachments">
+        /// Array of FileAttachmentRequest objects specifying contribution files to be attached to this comment. 
+        /// Pass null or an empty array to leave file attachments unchanged.
+        /// </param>
+        /// <returns></returns>
+        [OperationContract]
+        [WebInvoke]
+        Comment EditComment(string sessionToken, int commentID,
+            string bodyText, bool isSynthesis, bool isContribution, bool isSpecification,
+            SynthesisRequest[] syntheses, FileAttachmentRequest[] attachments);
+
+        [OperationContract]
+        [WebInvoke]
+        int RemoveComment(string sessionToken, int commentID);
 
         [OperationContract]
         [WebInvoke]
         ContributionFile UploadFile(Stream stream);
 
         [OperationContract]
-        [WebInvoke] // WebInvoke might not work here without some tinkering
+        [WebInvoke]
         Stream DownloadFile(int contributionFileID);
 
         [OperationContract]

--- a/BrainfarmWeb/scripts/Comment.txt
+++ b/BrainfarmWeb/scripts/Comment.txt
@@ -12,31 +12,31 @@
                 #{{CommentID}}
             </span>
         </div>
-        <div class="commentRibbons">
-            {{#unless ParentCommentID}}
-                <div class="ribbon initial">PROJECT</div>
-            {{/unless}}
-            {{#if IsSynthesis}}
-                <div class="ribbon synth">SYNTHESIS</div>
-            {{/if}}
-            {{#if IsSpecification}}
-                <div class="ribbon spec">SPECIFICATION</div>
-            {{/if}}
-            {{#if IsContribution}}
-                <div class="ribbon contrib">CONTRIBUTION</div>
-            {{/if}}
-        </div>
         {{#unless IsRemoved}}
+            <div class="commentRibbons">
+                {{#unless ParentCommentID}}
+                    <div class="ribbon initial">PROJECT</div>
+                {{/unless}}
+                {{#if IsSynthesis}}
+                    <div class="ribbon synth">SYNTHESIS</div>
+                {{/if}}
+                {{#if IsSpecification}}
+                    <div class="ribbon spec">SPECIFICATION</div>
+                {{/if}}
+                {{#if IsContribution}}
+                    <div class="ribbon contrib">CONTRIBUTION</div>
+                {{/if}}
+            </div>
             <div class="commentContent">
                 <div class="commentBody">
                     <p>{{BodyText}}</p>
                     {{#if IsSynthesis}}
                         <div class="synth-links">
                             {{#each this.Syntheses}}
-								<a href="#{{LinkedCommentID}}" data-commentid="{{LinkedCommentID}}" data-subject="{{Subject}}">
-									[{{LinkedCommentID}}] {{Subject}}
-								</a>
-								<br/>
+                                <a href="#{{LinkedCommentID}}" data-commentid="{{LinkedCommentID}}" data-subject="{{Subject}}">
+                                    [{{LinkedCommentID}}] {{Subject}}
+                                </a>
+                                <br/>
                             {{/each}}
                         </div>
                     {{/if}}
@@ -50,22 +50,22 @@
                     {{/if}}
                 </div>
                 <div class="commentOptions">
-				{{#isUserLoggedIn}}
-					<a class="btnReply" href="javascript:;">Reply</a>
-						<a class="btnBookmark" href="javascript:;">
-							{{#isBookmarked CommentID}}
-								Unbookmark
-							{{else}}
-								Bookmark
-							{{/isBookmarked}}
-						</a>
-					{{#isCurrentUser UserID}}
-						<a class="btnEdit" href="javascript:;">Edit</a>
-						<a class="btnRemove" href="javascript:;">Remove</a>
-					{{/isCurrentUser}}
-				{{else}}
-					<a class="btnLoginMessage" href="javascript:;">Log In to Reply</a>
-				{{/isUserLoggedIn}}
+                {{#isUserLoggedIn}}
+                    <a class="btnReply" href="javascript:;">Reply</a>
+                        <a class="btnBookmark" href="javascript:;">
+                            {{#isBookmarked CommentID}}
+                                Unbookmark
+                            {{else}}
+                                Bookmark
+                            {{/isBookmarked}}
+                        </a>
+                    {{#isCurrentUser UserID}}
+                        <a class="btnEdit" href="javascript:;">Edit</a>
+                        <a class="btnRemove" href="javascript:;">Remove</a>
+                    {{/isCurrentUser}}
+                {{else}}
+                    <a class="btnLoginMessage" href="javascript:;">Log In to Reply</a>
+                {{/isUserLoggedIn}}
                 </div>
             </div>
         {{/unless}}

--- a/BrainfarmWeb/scripts/Edit.html
+++ b/BrainfarmWeb/scripts/Edit.html
@@ -14,13 +14,22 @@
         </div>
         <div>
             <label><input type="checkbox" name="chkIsSynthesis">Synthesis Comment</label>
+            <br />
+            <div class="synthOptions" hidden>
+                Click on comments to add them to the synthesis list.
+                <ul class="synthList"></ul>
+            </div>
         </div>
         <div>
-            <label><input type="checkbox" name="chkIsContribution">Contribution Comment</label>
-        </div>
-        <div class="synthOptions" hidden>
-            Click on comments to add them to the synthesis list.
-            <ul class="synthList"></ul>
+            <label><input type="checkbox" class="chk-is-contribution" name="chkIsContribution">Contribution Comment</label>
+            <br />
+            <div class="div-file-upload reply-box-hidden">
+                <div class="btn-file-upload btn btn-green">
+                    <span>Upload File(s)</span>
+                    <input type="file" class="file-upload" multiple />
+                </div>
+                <span class="file-upload-label"></span>
+            </div>
         </div>
     </div>
 </div>

--- a/BrainfarmWeb/scripts/Project.js
+++ b/BrainfarmWeb/scripts/Project.js
@@ -298,10 +298,11 @@ function editCommentWithService(commentid, replyText, isSynthesis, isSpecificati
         sessionToken: sessionToken,
         commentID: commentid,
         bodyText: replyText,
-        syntheses: syntheses,
         isSynthesis: isSynthesis,
-        isContribution: isSpecification,
-        isSpecification: isContribution
+        isContribution: isContribution,
+        isSpecification: isSpecification,
+        syntheses: syntheses,
+        attachments: isContribution ? pendingFileUploads : null
     }
 
     serviceAjax("EditComment", args, reloadAndDisplayAllComments, handleServiceException);

--- a/BrainfarmWeb/scripts/Reply.html
+++ b/BrainfarmWeb/scripts/Reply.html
@@ -13,7 +13,12 @@
             <label><input type="checkbox" name="chkIsSpecification">Specification Comment</label>
         </div>
         <div>
-            <label ><input type="checkbox" name="chkIsSynthesis">Synthesis Comment</label>
+            <label><input type="checkbox" name="chkIsSynthesis">Synthesis Comment</label>
+            <br />
+            <div class="synthOptions" hidden>
+                Click on comments to add them to the synthesis list.
+                <ul class="synthList"></ul>
+            </div>
         </div>
         <div>
             <label><input type="checkbox" class="chk-is-contribution" name="chkIsContribution">Contribution Comment</label>
@@ -26,9 +31,6 @@
                 <span class="file-upload-label"></span>
             </div>
         </div>
-        <div class="synthOptions" hidden>
-            Click on comments to add them to the synthesis list.
-            <ul class="synthList"></ul>
-        </div>
+        
     </div>
 </div>


### PR DESCRIPTION
Contribution files can now be edited when a comment is edited. They will be deleted when a comment is removed.

When editing a comment if a client passes either null or an empty array for the list of contribution files to attach, no changes will be made to the comment's contribution files. Contribution files can still be removed by un-checking the "Is Contribution" checkbox. This is to prevent users from having to re-upload files any time they edit the comment.
Does that sound like a good approach?