### PR TITLE
Better token management

### DIFF
--- a/BrainfarmWeb/About.aspx.cs
+++ b/BrainfarmWeb/About.aspx.cs
@@ -7,11 +7,11 @@ using System.Web.UI.WebControls;
 
 namespace BrainfarmWeb
 {
-    public partial class About : System.Web.UI.Page
+    public partial class About : BrainfarmPage
     {
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-
+            base.Page_Load(sender, e);
         }
     }
 }

--- a/BrainfarmWeb/Account.aspx.cs
+++ b/BrainfarmWeb/Account.aspx.cs
@@ -10,14 +10,14 @@ using System.ServiceModel;
 
 namespace BrainfarmWeb
 {
-    public partial class Account : System.Web.UI.Page
+    public partial class Account : BrainfarmPage
     {
         protected string sessionToken;
         protected int userID;
 
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-
+            base.Page_Load(sender, e);
         }
 
         protected void Page_LoadComplete(object sender, EventArgs e)
@@ -46,7 +46,7 @@ namespace BrainfarmWeb
             }
 
             // Set instance variables to be injected into javascript
-            sessionToken = (string)Session["ServiceSessionToken"];
+            sessionToken = GetServiceSessionToken();
             userID = currentUser.UserID;
         }
 
@@ -88,47 +88,6 @@ namespace BrainfarmWeb
                 projectPanels.Add(projectPanel);
             }
             return projectPanels;
-        }
-
-        private User GetCurrentUser()
-        {
-            User currentUser = null;
-
-            // Get current user
-            if (Session["ServiceSessionToken"] != null)
-            {
-                // Service session token exists - user should be logged in
-                try
-                {
-                    using (BrainfarmServiceClient svc = new BrainfarmServiceClient())
-                    {
-                        currentUser = svc.GetCurrentUser((string)Session["ServiceSessionToken"]);
-                    }
-                }
-                catch (FaultException ex)
-                {
-                    currentUser = null;
-                }
-                catch
-                {
-                    Response.StatusCode = 500;
-                    Response.Redirect("/error/500.html");
-                }
-                // If service responds with null, clear the attempted session token and return to the homepage
-                // Essentially, if the session is no longer valid, make it look like a logout
-                if (currentUser == null)
-                {
-                    Session.Remove("ServiceSessionToken");
-                    Response.Redirect("/Default.aspx");
-                }
-            }
-            else
-            {
-                // Service session token does not exist - user not logged in
-                currentUser = null;
-            }
-
-            return currentUser;
         }
     }
 }

--- a/BrainfarmWeb/BrainfarmPage.cs
+++ b/BrainfarmWeb/BrainfarmPage.cs
@@ -1,0 +1,99 @@
+﻿using BrainfarmWeb.BrainfarmServiceReference;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Web;
+
+namespace BrainfarmWeb
+{
+    public class BrainfarmPage : System.Web.UI.Page
+    {
+        protected virtual void Page_Load(object sender, EventArgs e)
+        {
+            // Attempt to refresh the current session token if one exists
+            string oldToken = GetServiceSessionToken();
+            if (oldToken != null)
+            {
+                try
+                {
+                    using (BrainfarmServiceClient svc = new BrainfarmServiceClient())
+                    {
+                        string newToken = svc.RenewToken(oldToken);
+                        if (newToken != oldToken)
+                        {
+                            // Token changed
+                            SetServiceSessionToken(newToken);
+                        }
+                    }
+                }
+                catch
+                {
+
+                }
+            }
+        }
+
+        public string GetServiceSessionToken()
+        {
+            //return (string)Session["ServiceSessionToken"];
+            HttpCookie cookie = Request.Cookies.Get("ServiceSessionToken");
+            if (cookie != null)
+                return cookie.Value;
+            else
+                return null;
+        }
+
+        public void SetServiceSessionToken(string sessionToken)
+        {
+            //Session["ServiceSessionToken"] = sessionToken;
+            HttpCookie cookie = new HttpCookie("ServiceSessionToken", sessionToken);
+            if (sessionToken == null)
+            {
+                cookie.Expires = DateTime.Now.AddDays(-1); // set to expire
+            }
+            Response.Cookies.Add(cookie);
+            
+        }
+
+        public User GetCurrentUser()
+        {
+            User currentUser = null;
+            if (GetServiceSessionToken() != null)
+            {
+                // Service session token exists - user should be logged in
+                using (BrainfarmServiceClient svc = new BrainfarmServiceClient())
+                {
+                    try
+                    {
+                        currentUser = svc.GetCurrentUser(GetServiceSessionToken());
+                    }
+                    catch (FaultException)
+                    {
+                        currentUser = null;
+                    }
+                    catch
+                    {
+                        Response.StatusCode = 500;
+                        Response.Redirect("/error/500.html");
+                        return null;
+                    }
+                }
+                // If service responds with null, clear the attempted session token and return to the homepage
+                // Essentially, if the session is no longer valid, make it look like a logout
+                if (currentUser == null)
+                {
+                    SetServiceSessionToken(null);
+                    Response.Redirect("/Default.aspx");
+                    return null;
+                }
+            }
+            else
+            {
+                // Service session token does not exist - user not logged in
+                currentUser = null;
+            }
+            return currentUser;
+        }
+    }
+}

--- a/BrainfarmWeb/BrainfarmWeb.csproj
+++ b/BrainfarmWeb/BrainfarmWeb.csproj
@@ -164,6 +164,9 @@
     <Compile Include="Account.aspx.designer.cs">
       <DependentUpon>Account.aspx</DependentUpon>
     </Compile>
+    <Compile Include="BrainfarmPage.cs">
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
     <Compile Include="CreateProject.aspx.cs">
       <DependentUpon>CreateProject.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/BrainfarmWeb/CreateProject.aspx.cs
+++ b/BrainfarmWeb/CreateProject.aspx.cs
@@ -10,11 +10,11 @@ using System.Web.UI.WebControls;
 
 namespace BrainfarmWeb
 {
-    public partial class CreatePage : System.Web.UI.Page
+    public partial class CreatePage : BrainfarmPage
     {
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-
+            base.Page_Load(sender, e);
         }
 
         protected void btnCreateNewProject_Click(object sender, EventArgs e)
@@ -27,13 +27,13 @@ namespace BrainfarmWeb
             // -- get service session token information
             string serviceSessionToken = null;
 
-            if (Session["ServiceSessionToken"] == null) {
+            if (GetServiceSessionToken() == null) {
                 lblError.Text = "You must be logged in to create a new project. <br />";
                 lblError.Visible = true;
                 return;    
             }
             else {
-                serviceSessionToken = (string) Session["ServiceSessionToken"];
+                serviceSessionToken = GetServiceSessionToken();
             }
 
 

--- a/BrainfarmWeb/Default.aspx.cs
+++ b/BrainfarmWeb/Default.aspx.cs
@@ -10,18 +10,18 @@ using System.ServiceModel;
 
 namespace BrainfarmWeb
 {
-    public partial class Default : System.Web.UI.Page
+    public partial class Default : BrainfarmPage
     {
         protected string sessionToken;
 
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-            
+            base.Page_Load(sender, e);
         }
 
         protected void Page_LoadComplete(object sender, EventArgs e)
         {
-            sessionToken = (string)Session["ServiceSessionToken"];
+            sessionToken = GetServiceSessionToken();
             User currentUser = GetCurrentUser();
 
             // Display propper dashboard content
@@ -114,47 +114,6 @@ namespace BrainfarmWeb
                 projectPanels.Add(projectPanel);
             }
             return projectPanels;
-        }
-
-        private User GetCurrentUser()
-        {
-            User currentUser = null;
-
-            // Get current user
-            if (Session["ServiceSessionToken"] != null)
-            {
-                // Service session token exists - user should be logged in
-                try
-                {
-                    using (BrainfarmServiceClient svc = new BrainfarmServiceClient())
-                    {
-                        currentUser = svc.GetCurrentUser((string)Session["ServiceSessionToken"]);
-                    }
-                }
-                catch (FaultException ex)
-                {
-                    currentUser = null;
-                }
-                catch
-                {
-                    Response.StatusCode = 500;
-                    Response.Redirect("/error/500.html");
-                }
-                // If service responds with null, clear the attempted session token and return to the homepage
-                // Essentially, if the session is no longer valid, make it look like a logout
-                if (currentUser == null)
-                {
-                    Session.Remove("ServiceSessionToken");
-                    Response.Redirect("/Default.aspx");
-                }
-            }
-            else
-            {
-                // Service session token does not exist - user not logged in
-                currentUser = null;
-            }
-
-            return currentUser;
         }
     }
 }

--- a/BrainfarmWeb/Layout.Master
+++ b/BrainfarmWeb/Layout.Master
@@ -25,7 +25,6 @@
                 if (y < 0)
                     y = 0;
                 sidebar.css("top", y + "px");
-                console.log(header.height());
             });
         });
         

--- a/BrainfarmWeb/Layout.Master.cs
+++ b/BrainfarmWeb/Layout.Master.cs
@@ -24,40 +24,12 @@ namespace BrainfarmWeb
         private void SetHeaderContent()
         {
             User currentUser;
-
-            // Get current user
-            if (Session["ServiceSessionToken"] != null)
+            if (this.Page is BrainfarmPage)
             {
-                // Service session token exists - user should be logged in
-                using (BrainfarmServiceClient svc = new BrainfarmServiceClient())
-                {
-                    try
-                    {
-                        currentUser = svc.GetCurrentUser((string)Session["ServiceSessionToken"]);
-                    }
-                    catch (FaultException ex)
-                    {
-                        currentUser = null;
-                    }
-                    catch
-                    {
-                        Response.StatusCode = 500;
-                        Response.Redirect("/error/500.html");
-                        return;
-                    }
-                }
-                // If service responds with null, clear the attempted session token and return to the homepage
-                // Essentially, if the session is no longer valid, make it look like a logout
-                if (currentUser == null)
-                {
-                    Session.Remove("ServiceSessionToken");
-                    Response.Redirect("/Default.aspx");
-                    return;
-                }
+                currentUser = ((BrainfarmPage)this.Page).GetCurrentUser();
             }
             else
             {
-                // Service session token does not exist - user not logged in
                 currentUser = null;
             }
 
@@ -88,7 +60,7 @@ namespace BrainfarmWeb
                 try
                 {
                     string serviceSessionToken = svc.Login(username, password, remember);
-                    Session["ServiceSessionToken"] = serviceSessionToken;
+                    ((BrainfarmPage)this.Page).SetServiceSessionToken(serviceSessionToken);
                 }
                 catch (FaultException ex)
                 {
@@ -111,11 +83,11 @@ namespace BrainfarmWeb
 
         private void Logout()
         {
-            if (Session["ServiceSessionToken"] != null)
+            if (((BrainfarmPage)this.Page) != null)
             {
                 // Service uses JWTs to track state. 
                 // Logging out using JWTs simply meants throwing away your token.
-                Session.Remove("ServiceSessionToken");
+                ((BrainfarmPage)this.Page).SetServiceSessionToken(null);
             }
         }
 

--- a/BrainfarmWeb/Project.aspx.cs
+++ b/BrainfarmWeb/Project.aspx.cs
@@ -9,13 +9,15 @@ using System.Web.UI.WebControls;
 
 namespace BrainfarmWeb
 {
-    public partial class Project : System.Web.UI.Page
+    public partial class Project : BrainfarmPage
     {
         protected int projectID;
         protected string sessionToken;
 
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
+            base.Page_Load(sender, e);
+
             // Get project ID from the request
             if (!int.TryParse(Request.Params["ID"], out projectID))
             {
@@ -83,7 +85,7 @@ namespace BrainfarmWeb
 
         protected void Page_LoadComplete(object sender, EventArgs e)
         {
-            sessionToken = (string)Session["ServiceSessionToken"];
+            sessionToken = GetServiceSessionToken();
         }
     }
 }

--- a/BrainfarmWeb/Register.aspx.cs
+++ b/BrainfarmWeb/Register.aspx.cs
@@ -8,11 +8,11 @@ using BrainfarmWeb.BrainfarmServiceReference;
 
 namespace BrainfarmWeb
 {
-    public partial class Register : System.Web.UI.Page
+    public partial class Register : BrainfarmPage
     {
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-
+            base.Page_Load(sender, e);
         }
 
         protected void btnRegister_Click(object sender, EventArgs e)

--- a/BrainfarmWeb/SearchForProjects.aspx.cs
+++ b/BrainfarmWeb/SearchForProjects.aspx.cs
@@ -7,11 +7,11 @@ using System.Web.UI.WebControls;
 
 namespace BrainfarmWeb
 {
-    public partial class SearchForProjects : System.Web.UI.Page
+    public partial class SearchForProjects : BrainfarmPage
     {
-        protected void Page_Load(object sender, EventArgs e)
+        protected override void Page_Load(object sender, EventArgs e)
         {
-
+            base.Page_Load(sender, e);
         }
 
         protected void btnSearch_Click(object sender, EventArgs e)

--- a/BrainfarmWeb/scripts/Dashboard.js
+++ b/BrainfarmWeb/scripts/Dashboard.js
@@ -2,7 +2,7 @@
 
     $.when(getUserBookmarkedComments(), getCommentTemplate())
         .done(function (bookmarksResp, templateResp) {
-            if (bookmarksResp[1] == "success" && templateResp[1] == "success") {
+            if (bookmarksResp && bookmarksResp[1] == "success" && templateResp[1] == "success") {
                 prepareCommentTemplate(templateResp[0]);
                 mostRecentBookmarks = bookmarksResp[0].slice(0, 5); // Show only top 5
                 processComments(mostRecentBookmarks, "#div-bookmarks-list");
@@ -18,6 +18,10 @@
 });
 
 function getUserBookmarkedComments() {
+    // Don't make request if user is not logged in
+    if (sessionToken == null || sessionToken == "")
+        return null;
+
     var args = {
         sessionToken: sessionToken
     };


### PR DESCRIPTION
Merge this in after the "voting" branch is reviewed.
Made a base class "BrainfarmPage" that all other web pages now extend. This base class attempts to renew the session token whenever a page is loaded.
Session tokens are also now stored as cookies, rather than session variables.